### PR TITLE
Fix issue with double trigger of initialize call

### DIFF
--- a/simplefi-mstable-v2/src/fpmBTCHBTC.ts
+++ b/simplefi-mstable-v2/src/fpmBTCHBTC.ts
@@ -22,6 +22,11 @@ export function handleInitialize(call: InitializeCall): void {
   fakeEvent.address = call.to
   fakeEvent.block = call.block
 
+  let exists = FeederPoolEntity.load(fpmAssetAddress.toHexString())
+  if (exists != null) {
+    return
+  }
+
   let feederPool = new FeederPoolEntity(fpmAssetAddress.toHexString())
   feederPool.impl = call.to.toHexString()
   feederPool.mAsset = call.inputs._mAsset.addr.toHexString()

--- a/simplefi-mstable-v2/src/fpmBTCTBTC.ts
+++ b/simplefi-mstable-v2/src/fpmBTCTBTC.ts
@@ -22,6 +22,11 @@ export function handleInitialize(call: InitializeCall): void {
   fakeEvent.address = call.to
   fakeEvent.block = call.block
 
+  let exists = FeederPoolEntity.load(fpmAssetAddress.toHexString())
+  if (exists != null) {
+    return
+  }
+
   let feederPool = new FeederPoolEntity(fpmAssetAddress.toHexString())
   feederPool.impl = call.to.toHexString()
   feederPool.mAsset = call.inputs._mAsset.addr.toHexString()

--- a/simplefi-mstable-v2/src/imBTC.ts
+++ b/simplefi-mstable-v2/src/imBTC.ts
@@ -22,6 +22,11 @@ export function handleInitialize(call: InitializeCall): void {
   fakeEvent.address = call.to
   fakeEvent.block = call.block
 
+  let exists = IMAssetEntity.load(imAssetAddress.toHexString())
+  if (exists != null) {
+    return
+  }
+
   let contract = IMAsset.bind(imAssetAddress)
   let mBTC = contract.underlying()
 

--- a/simplefi-mstable-v2/src/mBTC.ts
+++ b/simplefi-mstable-v2/src/mBTC.ts
@@ -24,6 +24,11 @@ export function handleInitialize(call: InitializeCall): void {
   fakeEvent.address = call.to
   fakeEvent.block = call.block
 
+  let exists = MAssetEntity.load(mAssetAddress.toHexString())
+  if (exists != null) {
+    return
+  }
+
   let mAsset = new MAssetEntity(mAssetAddress.toHexString())
   let forgeValidator = call.inputs._forgeValidator
   let bAssetsData = call.inputs._bAssets

--- a/simplefi-mstable-v2/src/vimBTC.ts
+++ b/simplefi-mstable-v2/src/vimBTC.ts
@@ -22,6 +22,11 @@ export function handleInitialize(call: InitializeCall): void {
   fakeEvent.address = call.to
   fakeEvent.block = call.block
 
+  let exists = VIMAssetEntity.load(vimAssetAddress.toHexString())
+  if (exists != null) {
+    return
+  }
+
   let contract = VIMAsset.bind(vimAssetAddress)
   let imBTC = contract.stakingToken()
   let mta = contract.rewardsToken()


### PR DESCRIPTION
mBTC logic contract have a direct call to initialize their own storage values to random values. Our subgraph was triggering this `handleInitization` function twice once when the proxy is deployed and once when a direct call the logic contract is made. This second trigger was causing different values of `inputTokens` in `MAsset` and `Market` entities. Thus causing a lot of other issues with input token balances.