### PR TITLE
Merge volumetric data logic with standard Uni subgraph

### DIFF
--- a/uniswap-v2/schema.graphql
+++ b/uniswap-v2/schema.graphql
@@ -227,3 +227,57 @@ type Burn @entity {
 }
 
 # END - UniswapV2 protocol entities
+
+# Volumetric daily data
+type MarketDayData @entity {
+  " marketAddress + dayId "
+  id: ID!
+
+  " first trade of the day timestamp "
+  timestamp: BigInt!
+
+  " market id - pair address "
+  market: String!
+
+  "amount of input tokens swapped in "
+  inputTokensDailySwapInVolume: [String!]!
+
+  " amount of input tokens swapped out  "
+  inputTokensDailySwapOutVolume: [String!]!
+
+  " total amount of reserves per input token "
+  inputTokenTotalBalances: [String!]!
+
+  " reserve amount per input token this day "
+  inputTokenDailyInflow: [String!]!
+
+  " reserve amount per input token this day "
+  inputTokenDailyOutflow: [String!]!
+
+  " total balance of LP tokens "
+  outputTokenTotalBalance: BigInt!
+
+  " amount of LP tokens minted this day "
+  outputTokenDailyInflowVolume: BigInt!
+
+  " amount of LP tokens burned this day "
+  outputTokenDailyOutflowVolume: BigInt!
+
+  " fee percentage, applied to swap-in amount, taken by protocol "
+  protocolFee: BigInt!
+
+  " amount of fees generated this day, per token "
+  feesGenerated: [String!]!
+
+  " number of TXs this day swap "
+  dailySwapTXs: BigInt!
+
+  " number of TXs this day mint "
+  dailyMintTXs: BigInt!
+
+  " number of TXs this day burn "
+  dailyBurnTXs: BigInt!
+
+  " dayId - timestamp/86400 "
+  dayId: BigInt!
+}

--- a/uniswap-v2/src/constants.ts
+++ b/uniswap-v2/src/constants.ts
@@ -1,3 +1,5 @@
+import { BigInt, TypedMap } from "@graphprotocol/graph-ts"
+
 export namespace Blockchain {
   export const ETHEREUM = "ETHEREUM"
   export const BSC = "BSC"
@@ -53,3 +55,58 @@ export namespace TransactionType {
   export const TRANSFER_IN = "TRANSFER_IN"
   export const TRANSFER_OUT = "TRANSFER_OUT"
 }
+
+////////// Uni forks specfic config for tracking protocol fees
+
+export const APESWAP_BSC_FACTORY = "0x0841bd0b734e4f5853f0dd8d7ea041c241fb0da6"
+export const APESWAP_POLYGON_FACTORY = "0xcf083be4164828f00cae704ec15a36d711491284"
+export const AURORASWAP_AURORA_FACTORY = "0xc5e1daec2ad401ebebdd3e32516d90ab251a3aa3"
+export const BISWAP_BSC_FACTORY = "0x858e3312ed3a876947ea49d572a7c42de08af7ee"
+export const COMETH_POLYGON_FACTORY = "0x800b052609c355ca8103e06f022aa30647ead60a"
+export const PANCAKESWAP_BSC_FACTORY = "0xca143ce32fe78f1f7019d7d551a6402fc5350c73"
+export const PANGOLIN_AVALANCHE_FACTORY = "0xefa94de7a4656d787667c749f7e1223d71e9fd88"
+export const QUICKSWAP_POLYOGON_FACTORY = "0x5757371414417b8c6caad45baef941abc7d3ab32"
+export const SUSHISWAP_ARBITRUM_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const SUSHISWAP_AVALANCHE_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const SUSHISWAP_BSC_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const SUSHISWAP_CELO_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const SUSHISWAP_FANTOM_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const SUSHISWAP_MAINNET_FACTORY = "0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac"
+export const SUSHISWAP_POLYGON_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const SUSHISWAP_XDAI_FACTORY = "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
+export const TRADER_JOE_AVALANCHE_FACTORY = "0x9ad6c38be94206ca50bb0d90783181662f0cfa10"
+export const TRISOLARIS_AURORA_FACTORY = "0xc66f594268041db60507f00703b152492fb176e7"
+export const UNISWAP_V2_MAINNET_FACTORY = "0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f"
+export const WANNASWAP_AURORA_FACTORY = "0x7928d4fea7b2c90c732c10aff59cf403f0c38246"
+
+// 0.1%
+export const FEE_10_BASE_POINTS = 10
+// 0.2%
+export const FEE_20_BASE_POINTS = 20
+// 0.3%
+export const FEE_30_BASE_POINTS = 30
+// denominator
+export const FEE_DENOMINATOR = 10000
+
+// populate map
+export let protocolToFee = new TypedMap<string, BigInt>()
+protocolToFee.set(APESWAP_BSC_FACTORY, BigInt.fromI32(FEE_20_BASE_POINTS))
+protocolToFee.set(APESWAP_POLYGON_FACTORY, BigInt.fromI32(FEE_20_BASE_POINTS))
+protocolToFee.set(AURORASWAP_AURORA_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(BISWAP_BSC_FACTORY, BigInt.fromI32(FEE_10_BASE_POINTS))
+protocolToFee.set(COMETH_POLYGON_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(PANCAKESWAP_BSC_FACTORY, BigInt.fromI32(FEE_20_BASE_POINTS))
+protocolToFee.set(PANGOLIN_AVALANCHE_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(QUICKSWAP_POLYOGON_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_ARBITRUM_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_AVALANCHE_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_BSC_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_CELO_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_FANTOM_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_MAINNET_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_POLYGON_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(SUSHISWAP_XDAI_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(TRADER_JOE_AVALANCHE_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(TRISOLARIS_AURORA_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(UNISWAP_V2_MAINNET_FACTORY, BigInt.fromI32(FEE_30_BASE_POINTS))
+protocolToFee.set(WANNASWAP_AURORA_FACTORY, BigInt.fromI32(FEE_20_BASE_POINTS))

--- a/uniswap-v2/src/uniswapV2Factory.ts
+++ b/uniswap-v2/src/uniswapV2Factory.ts
@@ -1,15 +1,9 @@
-import { BigInt } from "@graphprotocol/graph-ts"
+import { BigInt, DataSourceContext } from "@graphprotocol/graph-ts"
 import { Pair as PairEntity } from "../generated/schema"
 import { UniswapV2Pair } from "../generated/templates"
-import {
-  PairCreated
-} from "../generated/UniswapV2Factory/UniswapV2Factory"
-import {
-  getOrCreateAccount,
-  getOrCreateERC20Token,
-  getOrCreateMarket
-} from "./common"
-import { ProtocolType } from "./constants"
+import { PairCreated } from "../generated/UniswapV2Factory/UniswapV2Factory"
+import { getOrCreateAccount, getOrCreateERC20Token, getOrCreateMarket } from "./common"
+import { FEE_30_BASE_POINTS, protocolToFee, ProtocolType } from "./constants"
 
 export function handlePairCreated(event: PairCreated, protocolName: string): void {
   // Create a tokens and market entity
@@ -43,5 +37,23 @@ export function handlePairCreated(event: PairCreated, protocolName: string): voi
   pair.save()
 
   // Start listening for market events
-  UniswapV2Pair.create(event.params.pair)
+  let context = new DataSourceContext()
+  context.setBigInt("protocolFee", getProtocolFee(event.address.toHexString()))
+  UniswapV2Pair.createWithContext(event.params.pair, context)
+}
+
+/**
+ * Get protocol's swap fee by looking at static mapping in constants
+ * @param address
+ * @returns
+ */
+function getProtocolFee(address: string): BigInt {
+  let fee = protocolToFee.get(address)
+
+  if (fee == null) {
+    // if not found, use Uniswap default of 0.3% swap fee (30 bps)
+    fee = BigInt.fromI32(FEE_30_BASE_POINTS)
+  }
+
+  return fee as BigInt
 }

--- a/uniswap-v2/src/uniswapV2Pair.ts
+++ b/uniswap-v2/src/uniswapV2Pair.ts
@@ -459,9 +459,9 @@ export function handleSync(event: Sync): void {
     // Update market
     let market = MarketEntity.load(event.address.toHexString()) as MarketEntity
     updateMarket(
-      event, 
-      market, 
-      inputTokenBalances, 
+      event,
+      market,
+      inputTokenBalances,
       pair.totalSupply
     )
   }

--- a/uniswap-v2/src/uniswapV2Pair.ts
+++ b/uniswap-v2/src/uniswapV2Pair.ts
@@ -1,15 +1,17 @@
-import { Address, BigInt, ethereum, store } from "@graphprotocol/graph-ts"
+import { Address, BigInt, dataSource, ethereum, store } from "@graphprotocol/graph-ts"
 import {
   Account as AccountEntity,
   AccountLiquidity as AccountLiquidityEntity,
   Burn as BurnEntity,
   Market as MarketEntity,
+  MarketDayData,
   Mint as MintEntity,
   Pair as PairEntity
 } from "../generated/schema"
 import {
   Burn,
   Mint,
+  Swap,
   Sync,
   Transfer
 } from "../generated/templates/UniswapV2Pair/UniswapV2Pair"
@@ -21,7 +23,7 @@ import {
   TokenBalance,
   updateMarket
 } from "./common"
-
+import { FEE_DENOMINATOR } from "./constants"
 
 function getOrCreateMint(event: ethereum.Event, pair: PairEntity): MintEntity {
   let mintId = pair.id.concat("-").concat(event.transaction.hash.toHexString())
@@ -285,6 +287,14 @@ export function handleTransfer(event: Transfer): void {
     if (toHex == ADDRESS_ZERO) {
       pair.totalSupply = pair.totalSupply.plus(event.params.value)
       pair.save()
+
+      // update inflow (mint) volume
+      let marketDayData = getMarketDayData(event)
+      marketDayData.outputTokenTotalBalance = pair.totalSupply
+      marketDayData.outputTokenDailyInflowVolume = marketDayData.outputTokenDailyInflowVolume.plus(
+        event.params.value
+      )
+      marketDayData.save()
     }
 
     let mint = getOrCreateMint(event, pair)
@@ -332,6 +342,21 @@ export function handleMint(event: Mint): void {
   mint.save()
   createOrUpdatePositionOnMint(event, pair, mint)
   checkIncompleteBurnFromLastTransaction(event, pair)
+
+  // update daily inputTokenDailyInflow per token
+  let marketDayData = getMarketDayData(event)
+
+  let inflows = marketDayData.inputTokenDailyInflow
+  let prevToken0Inflow = TokenBalance.fromString(inflows[0]).balance
+  let prevToken1Inflow = TokenBalance.fromString(inflows[1]).balance
+
+  let inputTokenDailyInflow: TokenBalance[] = [
+    new TokenBalance(pair.token0, pair.id, prevToken0Inflow.plus(event.params.amount0)),
+    new TokenBalance(pair.token1, pair.id, prevToken1Inflow.plus(event.params.amount1)),
+  ]
+  marketDayData.inputTokenDailyInflow = inputTokenDailyInflow.map<string>((tb) => tb.toString())
+  marketDayData.dailyMintTXs = marketDayData.dailyMintTXs.plus(BigInt.fromI32(1))
+  marketDayData.save()
 }
 
 export function handleBurn(event: Burn): void {
@@ -344,6 +369,21 @@ export function handleBurn(event: Burn): void {
   burn.save()
   createOrUpdatePositionOnBurn(event, pair, burn)
   checkIncompleteBurnFromLastTransaction(event, pair)
+
+  // update daily inputTokenDailyOutflow per token
+  let marketDayData = getMarketDayData(event)
+
+  let outflows = marketDayData.inputTokenDailyOutflow
+  let prevToken0Outflow = TokenBalance.fromString(outflows[0]).balance
+  let prevToken1Outflow = TokenBalance.fromString(outflows[1]).balance
+
+  let inputTokenDailyOutflow: TokenBalance[] = [
+    new TokenBalance(pair.token0, pair.id, prevToken0Outflow.plus(event.params.amount0)),
+    new TokenBalance(pair.token1, pair.id, prevToken1Outflow.plus(event.params.amount1)),
+  ]
+  marketDayData.inputTokenDailyOutflow = inputTokenDailyOutflow.map<string>((tb) => tb.toString())
+  marketDayData.dailyBurnTXs = marketDayData.dailyBurnTXs.plus(BigInt.fromI32(1))
+  marketDayData.save()
 }
 
 export function handleSync(event: Sync): void {
@@ -353,6 +393,17 @@ export function handleSync(event: Sync): void {
   pair.reserve0 = event.params.reserve0
   pair.reserve1 = event.params.reserve1
   pair.save()
+
+  // update inputTokenTotalBalances in marketDayData
+  let marketDayData = getMarketDayData(event)
+  let inputTokenTotalBalances: TokenBalance[] = [
+    new TokenBalance(pair.token0, pair.id, pair.reserve0),
+    new TokenBalance(pair.token1, pair.id, pair.reserve1),
+  ]
+  marketDayData.inputTokenTotalBalances = inputTokenTotalBalances.map<string>((tb) =>
+    tb.toString()
+  )
+  marketDayData.save()
 
   let isSyncOnly = true
 
@@ -366,6 +417,14 @@ export function handleSync(event: Sync): void {
 
     pair.totalSupply = pair.totalSupply.plus(mint.liquityAmount as BigInt)
     pair.save()
+
+    // update inflow (mint) volume
+    let marketDayData = getMarketDayData(event)
+    marketDayData.outputTokenTotalBalance = pair.totalSupply
+    marketDayData.outputTokenDailyInflowVolume = marketDayData.outputTokenDailyInflowVolume.plus(
+      mint.liquityAmount as BigInt
+    )
+    marketDayData.save()
 
     createOrUpdatePositionOnMint(event, pair, mint)
   }
@@ -381,6 +440,14 @@ export function handleSync(event: Sync): void {
     pair.totalSupply = pair.totalSupply.minus(burn.liquityAmount as BigInt)
     pair.save()
 
+    // update outflow (burn) volume
+    let marketDayData = getMarketDayData(event)
+    marketDayData.outputTokenTotalBalance = pair.totalSupply
+    marketDayData.outputTokenDailyOutflowVolume = marketDayData.outputTokenDailyOutflowVolume.plus(
+      burn.liquityAmount as BigInt
+    )
+    marketDayData.save()
+
     createOrUpdatePositionOnBurn(event, pair, burn)
   }
 
@@ -392,12 +459,154 @@ export function handleSync(event: Sync): void {
     // Update market
     let market = MarketEntity.load(event.address.toHexString()) as MarketEntity
     updateMarket(
-      event,
-      market,
-      inputTokenBalances,
+      event, 
+      market, 
+      inputTokenBalances, 
       pair.totalSupply
     )
   }
 
   checkIncompleteBurnFromLastTransaction(event, pair)
+}
+
+/**
+ * Handle swap by increasing daily swap volume per token and swap TX counter.
+ * @param event
+ */
+export function handleSwap(event: Swap): void {
+  let pairAddress = event.address.toHexString()
+  let pair = PairEntity.load(pairAddress) as PairEntity
+
+  // update daily swap volume per token
+  let marketDayData = getMarketDayData(event)
+
+  // update swap in volumes
+  let swapInVolumes = marketDayData.inputTokensDailySwapInVolume
+  let swapInVolume0 = TokenBalance.fromString(swapInVolumes[0]).balance
+  let swapInVolume1 = TokenBalance.fromString(swapInVolumes[1]).balance
+
+  let inputTokensDailySwapInVolume: TokenBalance[] = [
+    new TokenBalance(pair.token0, pairAddress, swapInVolume0.plus(event.params.amount0In)),
+    new TokenBalance(pair.token1, pairAddress, swapInVolume1.plus(event.params.amount1In)),
+  ]
+  marketDayData.inputTokensDailySwapInVolume = inputTokensDailySwapInVolume.map<string>((tb) =>
+    tb.toString()
+  )
+
+  // update swap out volumes
+  let swapOutVolumes = marketDayData.inputTokensDailySwapOutVolume
+  let swapOutVolume0 = TokenBalance.fromString(swapOutVolumes[0]).balance
+  let swapOutVolume1 = TokenBalance.fromString(swapOutVolumes[1]).balance
+
+  let inputTokensDailySwapOutVolume: TokenBalance[] = [
+    new TokenBalance(pair.token0, pairAddress, swapOutVolume0.plus(event.params.amount0Out)),
+    new TokenBalance(pair.token1, pairAddress, swapOutVolume1.plus(event.params.amount1Out)),
+  ]
+  marketDayData.inputTokensDailySwapOutVolume = inputTokensDailySwapOutVolume.map<string>((tb) =>
+    tb.toString()
+  )
+
+  // update TX counter
+  marketDayData.dailySwapTXs = marketDayData.dailySwapTXs.plus(BigInt.fromI32(1))
+
+  // update fees collected
+  let swapFeeToken0 = event.params.amount0In
+    .times(marketDayData.protocolFee)
+    .div(BigInt.fromI32(FEE_DENOMINATOR))
+  let swapFeeToken1 = event.params.amount1In
+    .times(marketDayData.protocolFee)
+    .div(BigInt.fromI32(FEE_DENOMINATOR))
+
+  let prevFees = marketDayData.feesGenerated
+  let prevFees0 = TokenBalance.fromString(prevFees[0]).balance
+  let prevFees1 = TokenBalance.fromString(prevFees[1]).balance
+
+  let swapFeesDailyCumulatedToken0 = prevFees0.plus(swapFeeToken0)
+  let swapFeesDailyCumulatedToken1 = prevFees1.plus(swapFeeToken1)
+
+  let feesGenerated: TokenBalance[] = [
+    new TokenBalance(pair.token0, pairAddress, swapFeesDailyCumulatedToken0),
+    new TokenBalance(pair.token1, pairAddress, swapFeesDailyCumulatedToken1),
+  ]
+  marketDayData.feesGenerated = feesGenerated.map<string>((tb) => tb.toString())
+  marketDayData.save()
+}
+
+/**
+ * Get/create and init MarketDayData entity.
+ * @param event
+ * @returns
+ */
+function getMarketDayData(event: ethereum.Event): MarketDayData {
+  let pairAddress = event.address.toHexString()
+  let timestamp = event.block.timestamp.toI32()
+  // UTC day is 86400 seconds long
+  let dayID = timestamp / 86400
+  let dayPairID = pairAddress.concat("-").concat(BigInt.fromI32(dayID).toString())
+
+  let pair = PairEntity.load(pairAddress) as PairEntity
+  let marketDayData = MarketDayData.load(dayPairID)
+  if (marketDayData == null) {
+    marketDayData = new MarketDayData(dayPairID)
+    marketDayData.timestamp = event.block.timestamp
+    marketDayData.market = pairAddress
+
+    let inputTokensDailySwapInVolume: TokenBalance[] = [
+      new TokenBalance(pair.token0, pairAddress, BigInt.fromI32(0)),
+      new TokenBalance(pair.token1, pairAddress, BigInt.fromI32(0)),
+    ]
+    marketDayData.inputTokensDailySwapInVolume = inputTokensDailySwapInVolume.map<string>((tb) =>
+      tb.toString()
+    )
+
+    let inputTokensDailySwapOutVolume: TokenBalance[] = [
+      new TokenBalance(pair.token0, pairAddress, BigInt.fromI32(0)),
+      new TokenBalance(pair.token1, pairAddress, BigInt.fromI32(0)),
+    ]
+    marketDayData.inputTokensDailySwapOutVolume = inputTokensDailySwapOutVolume.map<string>((tb) =>
+      tb.toString()
+    )
+
+    let inputTokenDailyInflow: TokenBalance[] = [
+      new TokenBalance(pair.token0, pairAddress, BigInt.fromI32(0)),
+      new TokenBalance(pair.token1, pairAddress, BigInt.fromI32(0)),
+    ]
+    marketDayData.inputTokenDailyInflow = inputTokenDailyInflow.map<string>((tb) => tb.toString())
+
+    let inputTokenDailyOutflow: TokenBalance[] = [
+      new TokenBalance(pair.token0, pairAddress, BigInt.fromI32(0)),
+      new TokenBalance(pair.token1, pairAddress, BigInt.fromI32(0)),
+    ]
+    marketDayData.inputTokenDailyOutflow = inputTokenDailyOutflow.map<string>((tb) =>
+      tb.toString()
+    )
+
+    marketDayData.outputTokenDailyInflowVolume = BigInt.fromI32(0)
+    marketDayData.outputTokenDailyOutflowVolume = BigInt.fromI32(0)
+    marketDayData.protocolFee = dataSource.context().getBigInt("protocolFee")
+
+    let feesGenerated: TokenBalance[] = [
+      new TokenBalance(pair.token0, pairAddress, BigInt.fromI32(0)),
+      new TokenBalance(pair.token1, pairAddress, BigInt.fromI32(0)),
+    ]
+    marketDayData.feesGenerated = feesGenerated.map<string>((tb) => tb.toString())
+
+    marketDayData.dailySwapTXs = BigInt.fromI32(0)
+    marketDayData.dailyMintTXs = BigInt.fromI32(0)
+    marketDayData.dailyBurnTXs = BigInt.fromI32(0)
+    marketDayData.dayId = BigInt.fromI32(dayID)
+
+    let inputTokenTotalBalances: TokenBalance[] = [
+      new TokenBalance(pair.token0, pairAddress, pair.reserve0),
+      new TokenBalance(pair.token1, pairAddress, pair.reserve1),
+    ]
+    marketDayData.inputTokenTotalBalances = inputTokenTotalBalances.map<string>((tb) =>
+      tb.toString()
+    )
+
+    marketDayData.outputTokenTotalBalance = pair.totalSupply
+    marketDayData.save()
+  }
+
+  return marketDayData as MarketDayData
 }

--- a/uniswap-v2/subgraph.template.yaml
+++ b/uniswap-v2/subgraph.template.yaml
@@ -66,3 +66,5 @@ templates:
           handler: handleMint
         - event: Burn(indexed address,uint256,uint256,indexed address)
           handler: handleBurn
+        - event: Swap(indexed address,uint256,uint256,uint256,uint256,indexed address)
+          handler: handleSwap


### PR DESCRIPTION
Volumetric data tracking was developed as separate subgraph -> `[subgraphs/protocol-volumes/uniswap-v2](https://github.com/SimpleFi-finance/subgraphs/tree/master/protocol-volumes/uniswap-v2)`

This PR merges the volumetric data code and schema with standard subgraph we've been using for Uni and its forks. Idea is to deploy these complete subgraphs to main net.