### PR TITLE
Check of null user info in case of emergency withdrawal

### DIFF
--- a/stake-dao/src/stakeDAOMasterChef.ts
+++ b/stake-dao/src/stakeDAOMasterChef.ts
@@ -263,7 +263,12 @@ export function handleEmergencyWithdraw(event: EmergencyWithdraw): void {
   let poolInfo = MCPoolInfoEntity.load(id) as MCPoolInfoEntity
 
   let uid = masterChef.id.concat("-").concat(event.params.user.toHexString())
-  let userInfo = MCUserInfoEntity.load(uid) as MCUserInfoEntity
+  let userInfo = MCUserInfoEntity.load(uid)
+  if (userInfo == null) {
+    return
+  } else {
+    userInfo = userInfo as MCUserInfoEntity
+  }
   userInfo.amount = BigInt.fromI32(0)
   userInfo.rewardDebt = BigInt.fromI32(0)
   userInfo.save()

--- a/stake-dao/subgraph.yaml
+++ b/stake-dao/subgraph.yaml
@@ -1,6 +1,9 @@
 specVersion: 0.0.2
 schema:
   file: ./schema.graphql
+graft:
+  base: QmPVp59XG3uHJUT8RF4w4YoyESAfDeH69HCsaHJ27wEZ9A
+  block: 14544048
 dataSources:
   - kind: ethereum/contract
     name: StakeDAOController


### PR DESCRIPTION
Fix issue in Stake-DAO subgraph. It was failing because a user called emergency withdraw without depositing anything.